### PR TITLE
#10 obfuscate コマンドの高速化，進捗バーの表示

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -192,6 +192,7 @@ dependencies = [
  "instant",
  "number_prefix",
  "portable-atomic",
+ "rayon",
  "unicode-width",
 ]
 
@@ -224,9 +225,9 @@ checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 
 [[package]]
 name = "libc"
-version = "0.2.153"
+version = "0.2.155"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c198f91728a82281a64e1f4f9eeb25d82cb32a5de251c6bd1b5154d63a8e7bd"
+checksum = "97b3888a4aecf77e811145cadf6eef5901f4782c53886191b2f693f24761847c"
 
 [[package]]
 name = "memchr"
@@ -258,10 +259,11 @@ checksum = "830b246a0e5f20af87141b25c173cd1b609bd7779a4617d6ec582abaf90870f3"
 
 [[package]]
 name = "obfus-eval"
-version = "2024.4.18"
+version = "2024.5.30"
 dependencies = [
  "anyhow",
  "clap",
+ "console",
  "duct",
  "indicatif",
  "json",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "obfus-eval"
-version = "2024.4.18"
+version = "2024.5.30"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
@@ -8,8 +8,9 @@ edition = "2021"
 [dependencies]
 anyhow = "1.0.80"
 clap = { version = "4.5.4", features = ["derive"] }
+console = "0.15.8"
 duct = "0.13.7"
-indicatif = "0.17.8"
+indicatif = { version = "0.17.8", features = ["rayon"]}
 json = "0.12.4"
 nom = "7.1.3"
 rayon = "1.10.0"

--- a/src/command/obfuscate.rs
+++ b/src/command/obfuscate.rs
@@ -1,11 +1,15 @@
 use anyhow::Result;
-use indicatif::{ProgressBar, ProgressStyle};
-use rayon::prelude::*;
+use console::style;
+use indicatif::{MultiProgress, ProgressBar, ProgressStyle};
+use rayon::iter::{IntoParallelRefIterator, ParallelIterator};
 use std::path::PathBuf;
 
 use clap::Parser;
 
-use crate::model::{dataset::Dataset, obfuscator::ObfuscatorTrait};
+use crate::model::{
+    dataset::Dataset,
+    obfuscator::{Obfuscator, ObfuscatorTrait},
+};
 
 use super::Command;
 
@@ -34,31 +38,52 @@ impl ObfuscateCommand {
 
 impl Command for ObfuscateCommand {
     fn run(&self) -> Result<()> {
-        let bar = ProgressBar::new(self.dataset.code_db.len() as u64);
-        bar.set_style(
-            ProgressStyle::with_template(
-                "{spinner} [{elapsed_precise}] {bar:40.cyan/blue} {pos:>7}/{len:7} {msg}",
-            )
-            .unwrap(),
-        );
-
         self.dataset
             .obfuscator_db
-            .par_iter()
-            .for_each(|obfuscator| {
-                for code in self.dataset.code_db.iter() {
-                    if let Some(target) = &self.target {
-                        if !code.dir_name.eq(target) {
-                            continue;
-                        }
-                    }
-
-                    let _ = obfuscator.obfuscate(&self.dataset, &code);
-                    bar.inc(1);
-                    bar.set_message(format!("{}", code.target));
-                }
+            .iter()
+            .enumerate()
+            .for_each(|(idx, obfuscator)| {
+                println!(
+                    "{} ({}) Obfuscate source code",
+                    style(format!("[{}/1]", idx + 1)).bold().dim(),
+                    style(format!("{}", obfuscator.name)).bold().dim(),
+                );
+                self.obfuscate_each_code(obfuscator);
             });
 
         Ok(())
+    }
+}
+
+impl ObfuscateCommand {
+    fn obfuscate_each_code(&self, obfuscator: &Obfuscator) {
+        let mp = MultiProgress::new();
+        let obfuscation_len = obfuscator.transformation_set.len() as u64;
+        let pb_style = ProgressStyle::with_template(
+            "{spinner:.green} [{elapsed_precise}] {prefix} {bar:40.cyan/blue} {pos:>7}/{len:7} {msg}",
+        )
+        .unwrap()
+        .progress_chars("#>-");
+
+        let _: Vec<_> = self
+            .dataset
+            .code_db
+            .par_iter()
+            .map(|code| {
+                if let Some(target) = &self.target {
+                    if !code.dir_name.eq(target) {
+                        return;
+                    }
+                }
+
+                let pb = mp.add(ProgressBar::new(obfuscation_len));
+                pb.set_style(pb_style.clone());
+                pb.set_prefix(format!("{:<10}", code.target));
+
+                let _ = obfuscator.obfuscate(&self.dataset, &code, &pb);
+            })
+            .collect();
+
+        // mp.clear().unwrap();
     }
 }

--- a/src/model/obfuscator.rs
+++ b/src/model/obfuscator.rs
@@ -1,24 +1,26 @@
-use std::fs;
+use std::{fs, time::Duration};
 
 use self::{code::CodeInfo, dataset::Dataset, obfuscation::Obfuscation};
 use super::*;
 use anyhow::Result;
 use duct::{cmd, Expression};
+use indicatif::{ProgressBar, ProgressStyle};
+use rayon::iter::{IntoParallelRefIterator, ParallelIterator};
 
 pub trait ObfuscatorTrait {
-    fn obfuscate(&self, dataset: &Dataset, code: &CodeInfo) -> Result<()>;
+    fn obfuscate(&self, dataset: &Dataset, code: &CodeInfo, target_pb: &ProgressBar) -> Result<()>;
 }
 
 #[derive(Debug, Deserialize, Serialize)]
 pub struct Obfuscator {
-    name: String,
+    pub name: String,
     execution_path: PathBuf,
     common_parameter: Vec<String>,
     pub transformation_set: Vec<Obfuscation>,
 }
 
 impl ObfuscatorTrait for Obfuscator {
-    fn obfuscate(&self, dataset: &Dataset, code: &CodeInfo) -> Result<()> {
+    fn obfuscate(&self, dataset: &Dataset, code: &CodeInfo, target_pb: &ProgressBar) -> Result<()> {
         // 難読化のコマンドと共通パラメータを設定
         let (command, obfuscate_param): (&str, Vec<String>) =
             self.make_common_command(&dataset.docker_compose_file);
@@ -30,24 +32,36 @@ impl ObfuscatorTrait for Obfuscator {
             let _ = fs::create_dir(&dst_dir_path);
         }
 
-        for obfuscation in self.transformation_set.iter() {
-            let dst_path: &PathBuf = &dst_dir_path
-                .join(&obfuscation.display_name)
-                .with_extension("c");
-            if dst_path.exists() {
-                continue;
-            }
+        let _: Vec<_> = self
+            .transformation_set
+            .par_iter()
+            .map(|obfuscation| {
+                let dst_path: &PathBuf = &dst_dir_path
+                    .join(&obfuscation.display_name)
+                    .with_extension("c");
+                if dst_path.exists() {
+                    return;
+                }
 
-            let obfuscation_param: Vec<String> = obfuscation.get_obfuscate_parameter(code);
-            let io_param: Vec<String> = Obfuscator::get_io_parameter(&src_path, &dst_path);
-            let args = [obfuscate_param.clone(), obfuscation_param, io_param].concat();
+                target_pb.enable_steady_tick(Duration::from_millis(100));
+                target_pb.set_message(format!("{:<10}", &obfuscation.display_name));
 
-            // 成否判定(コードが生成されていれば，とりあえずOKとする)
-            let command: Expression = cmd(command, args);
-            // dbg!(&command);
-            let _output = command.unchecked().stderr_capture().run();
-            // dbg!(&_output);
-        }
+                let obfuscation_param: Vec<String> = obfuscation.get_obfuscate_parameter(code);
+                let io_param: Vec<String> = Obfuscator::get_io_parameter(&src_path, &dst_path);
+                let args = [obfuscate_param.clone(), obfuscation_param, io_param].concat();
+
+                // 成否判定(コードが生成されていれば，とりあえずOKとする)
+                let command: Expression = cmd(command, args);
+                let _output = command.unchecked().stdout_null().stderr_capture().run();
+
+                target_pb.inc(1);
+            })
+            .collect();
+
+        let pb_style =
+            ProgressStyle::with_template("   [{elapsed_precise}] {prefix} {msg}").unwrap();
+        target_pb.set_style(pb_style);
+        target_pb.finish_with_message("obfuscated.");
 
         Ok(())
     }

--- a/tests/resource/sample_dataset/dataset.json
+++ b/tests/resource/sample_dataset/dataset.json
@@ -4,7 +4,7 @@
     "obfuscator_db": [
         "../obfuscator_db/tigress.json"
     ],
-    "docker_compose_file": "../docker-compdose.yml",
+    "docker_compose_file": "../docker-compose.yml",
     "code_db": [
         {
             "dir_name": "sample1",


### PR DESCRIPTION
難読化対象のコードごと，難読化手法ごとにスレッドを分割し全体の処理時間を短くした．
また，進捗バーを追加している．

## Memo
- とりあえず進捗バーは実行が終わった後もそのまま表示にしている
- ProgressBarを引数に追加しているため，APIの整理を何処かで行う必要がある